### PR TITLE
stores

### DIFF
--- a/RELEASE/scripts/autoscend/auto_util.ash
+++ b/RELEASE/scripts/autoscend/auto_util.ash
@@ -30,6 +30,7 @@ boolean acquireGumItem(item it);
 boolean acquireHermitItem(item it);
 boolean isHermitAvailable();
 boolean isGeneralStoreAvailable();
+boolean isMusGuildStoreAvailable();
 boolean isArmoryAvailable();
 boolean isGalaktikAvailable();
 boolean isUnclePAvailable();
@@ -2198,6 +2199,10 @@ boolean isGalaktikAvailable()
 	{
 		return false;
 	}
+	if(auto_my_path() == "Kingdom of Exploathing")
+	{
+		return false;
+	}
 	return true;
 }
 
@@ -2212,6 +2217,19 @@ boolean isGeneralStoreAvailable()
 		return false;
 	}
 	return true;
+}
+
+boolean isMusGuildStoreAvailable()
+{
+	if(($classes[seal clubber, turtle tamer] contains my_class()) && guild_store_available())
+	{
+		return true;
+	}
+	if ((my_class() == $class[accordion thief]) && (my_level() >= 9) && guild_store_available())
+	{
+		return true;
+	}
+	return false;
 }
 
 boolean isArmoryAvailable()
@@ -4228,7 +4246,7 @@ boolean buyUpTo(int num, item it, int maxprice)
 	{
 		return false;
 	}
-	if(($items[Blood of the Wereseal, Cheap Wind-Up Clock, Turtle Pheromones] contains it) && !guild_store_available())
+	if(($items[Blood of the Wereseal, Cheap Wind-Up Clock, Turtle Pheromones] contains it) && !isMusGuildStoreAvailable())
 	{
 		return false;
 	}

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -793,6 +793,7 @@ boolean isExpectingArrow();									//Defined in autoscend/auto_util.ash
 boolean isFreeMonster(monster mon);							//Defined in autoscend/auto_util.ash
 boolean isGalaktikAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGeneralStoreAvailable();							//Defined in autoscend/auto_util.ash
+boolean isMusGuildStoreAvailable();							//Defined in autoscend/auto_util.ash
 boolean isArmoryAvailable();								//Defined in autoscend/auto_util.ash
 boolean isGhost(monster mon);								//Defined in autoscend/auto_util.ash
 boolean isGuildClass();										//Defined in autoscend/auto_util.ash


### PR DESCRIPTION
1. galaktik is not available in exploathing
2. when trying to buy blood of the wereseal, cheap wind-up clock, or turtle pheromones it only checked if the current class guild store was available, instead of specifically if the smacketeria is available. Playing as a sauceror this lead to an error when autoscend tried to buy some blood of the wereseal. Added a function specifically for testing the smacketeria changed the existing test to use this new function.

# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
