### PR TITLE
exact skill tracking for different skills with same name.

### DIFF
--- a/RELEASE/scripts/autoscend/auto_awol.ash
+++ b/RELEASE/scripts/autoscend/auto_awol.ash
@@ -177,7 +177,7 @@ boolean awol_buySkills()
 					{
 						page = visit_url("choice.php?pwd=&option=1&whichchoice=1177&whichskill=1", true);
 					}
-					else if(!have_skill($skill[Hard Drinker]) && cowSlang)
+					else if(!have_skill($skill[[18008]Hard Drinker]) && cowSlang)
 					{
 						page = visit_url("choice.php?pwd=&option=1&whichchoice=1177&whichskill=8", true);
 					}
@@ -208,7 +208,7 @@ boolean awol_buySkills()
 				}
 				else
 				{
-					if(!have_skill($skill[Hard Drinker]) && cowSlang)
+					if(!have_skill($skill[[18008]Hard Drinker]) && cowSlang)
 					{
 						page = visit_url("choice.php?pwd=&option=1&whichchoice=1177&whichskill=8", true);
 					}

--- a/RELEASE/scripts/autoscend/auto_batpath.ash
+++ b/RELEASE/scripts/autoscend/auto_batpath.ash
@@ -227,7 +227,7 @@ int bat_maxHPCost(skill sk)
 		case $skill[Spot Weakness]:
 			return 15;
 		case $skill[Savage Bite]:
-		case $skill[Ferocity]:
+		case $skill[[24017]Ferocity]:
 		case $skill[Chill of the Tomb]:
 		case $skill[Spectral Awareness]:
 			return 10;
@@ -304,7 +304,7 @@ boolean[skill] bat_desiredSkills(int hpLeft, boolean[skill] forcedPicks)
 		Mist Form,
 		Sanguine Magnetism,
 		Macabre Cunning,
-		Ferocity,
+		[24017]Ferocity,
 		Flesh Scent,
 		Wolf Form,
 		Spot Weakness,

--- a/RELEASE/scripts/autoscend/auto_boris.ash
+++ b/RELEASE/scripts/autoscend/auto_boris.ash
@@ -222,7 +222,7 @@ boolean boris_buySkills()
 			{
 				tree = 1;
 			}
-			if(!have_skill($skill[Ferocity]))
+			if(!have_skill($skill[[11002]Ferocity]))
 			{
 				tree = 1;
 			}

--- a/RELEASE/scripts/autoscend/auto_combat.ash
+++ b/RELEASE/scripts/autoscend/auto_combat.ash
@@ -1668,17 +1668,18 @@ string auto_combatHandler(int round, string opp, string text)
 	{
 		// note: Juggle Fireballs CAN be used multiple times, but it is only
 		// useful if you have level 3 fire and therefore get healed
-		if(zelda_ppCurr() > 2 && canUse($skill[Juggle Fireballs], true))
+		if(zelda_ppCurr() > 2 && canUse($skill[[7332]Juggle Fireballs], true))
 		{
-			return useSkill($skill[Juggle Fireballs]);
+			return useSkill($skill[[7332]Juggle Fireballs]);
 		}
 
 		if (enemy.physical_resistance >= 80)
 		{
-			if (canUse($skill[Fireball Barrage], false))
+			if (canUse($skill[[7333]Fireball Barrage], false))
 			{
-				return useSkill($skill[Fireball Barrage]);
+				return useSkill($skill[[7333]Fireball Barrage]);
 			}
+			//this skill comes from the IOTM Beach Comb
 			if (canUse($skill[Beach Combo], true))
 			{
 				return useSkill($skill[Beach Combo]);
@@ -1689,10 +1690,11 @@ string auto_combatHandler(int round, string opp, string text)
 			}
 		}
 
-		if (canUse($skill[Multi-Bounce], false))
+		if (canUse($skill[[7336]Multi-Bounce], false))
 		{
-			return useSkill($skill[Multi-Bounce]);
+			return useSkill($skill[[7336]Multi-Bounce]);
 		}
+		//this skill comes from the IOTM Beach Comb
 		if (canUse($skill[Beach Combo], true))
 		{
 			return useSkill($skill[Beach Combo]);
@@ -1703,9 +1705,9 @@ string auto_combatHandler(int round, string opp, string text)
 		}
 
 		// Fallback, since maybe we only have fire flower equipped.
-		if (canUse($skill[Fireball Barrage], false))
+		if (canUse($skill[[7333]Fireball Barrage], false))
 		{
-			return useSkill($skill[Fireball Barrage]);
+			return useSkill($skill[[7333]Fireball Barrage]);
 		}
 		return useSkill($skill[Fireball Toss], false);
 	}

--- a/RELEASE/scripts/autoscend/auto_sneakypete.ash
+++ b/RELEASE/scripts/autoscend/auto_sneakypete.ash
@@ -132,7 +132,7 @@ boolean pete_buySkills()
 			{
 				tree = 3;
 			}
-			if(!have_skill($skill[Hard Drinker]))
+			if(!have_skill($skill[[15025]Hard Drinker]))
 			{
 				tree = 3;
 			}

--- a/RELEASE/scripts/autoscend/auto_zelda.ash
+++ b/RELEASE/scripts/autoscend/auto_zelda.ash
@@ -50,12 +50,12 @@ boolean zelda_equippedBoots()
 
 int zelda_numBadgesBought()
 {
-	return (have_skill($skill[Hammer Throw]).to_int() +
-		have_skill($skill[Ultra Smash]).to_int() +
-		have_skill($skill[Juggle Fireballs]).to_int() +
-		have_skill($skill[Fireball Barrage]).to_int() +
-		have_skill($skill[Spin Jump]).to_int() +
-		have_skill($skill[Multi-Bounce]).to_int() +
+	return (have_skill($skill[[25001]Hammer Throw]).to_int() +
+		have_skill($skill[[25002]Ultra Smash]).to_int() +
+		have_skill($skill[[25003]Juggle Fireballs]).to_int() +
+		have_skill($skill[[25004]Fireball Barrage]).to_int() +
+		have_skill($skill[[25005]Spin Jump]).to_int() +
+		have_skill($skill[[25006]Multi-Bounce]).to_int() +
 		have_skill($skill[Power Plus]).to_int() +
 		have_skill($skill[Secret Eye]).to_int() +
 		have_skill($skill[Lucky Buckle]).to_int() +
@@ -79,12 +79,12 @@ boolean zelda_buySkill(skill sk)
 	int idx = 0;
 	switch(sk)
 	{
-		case $skill[Hammer Throw]: idx=1; break;
-		case $skill[Ultra Smash]: idx=2; break;
-		case $skill[Juggle Fireballs]: idx=3; break;
-		case $skill[Fireball Barrage]: idx=4; break;
-		case $skill[Spin Jump]: idx=5; break;
-		case $skill[Multi-Bounce]: idx=6; break;
+		case $skill[[25001]Hammer Throw]: idx=1; break;
+		case $skill[[25002]Ultra Smash]: idx=2; break;
+		case $skill[[25003]Juggle Fireballs]: idx=3; break;
+		case $skill[[25004]Fireball Barrage]: idx=4; break;
+		case $skill[[25005]Spin Jump]: idx=5; break;
+		case $skill[[25006]Multi-Bounce]: idx=6; break;
 		case $skill[Power Plus]: idx=7; break;
 		case $skill[Secret Eye]: idx=8; break;
 		case $skill[Lucky Buckle]: idx=9; break;
@@ -207,9 +207,9 @@ zelda_buyable zelda_nextBuyable()
 	{
 		return zelda_buyableSkill($skill[Secret Eye]);
 	}
-	else if (!have_skill($skill[Multi-Bounce]))
+	else if (!have_skill($skill[[25006]Multi-Bounce]))
 	{
-		return zelda_buyableSkill($skill[Multi-Bounce]);
+		return zelda_buyableSkill($skill[[25006]Multi-Bounce]);
 	}
 	else if (!have_skill($skill[Power Plus]))
 	{
@@ -239,9 +239,9 @@ zelda_buyable zelda_nextBuyable()
 	{
 		return zelda_buyableSkill($skill[Rainbow Shield]);
 	}
-	else if (!have_skill($skill[Fireball Barrage]))
+	else if (!have_skill($skill[[25004]Fireball Barrage]))
 	{
-		return zelda_buyableSkill($skill[Fireball Barrage]);
+		return zelda_buyableSkill($skill[[25004]Fireball Barrage]);
 	}
 	else if (!possessEquipment($item[frosty button]))
 	{
@@ -251,9 +251,9 @@ zelda_buyable zelda_nextBuyable()
 	{
 		return zelda_buyableSkill($skill[Health Symbol]);
 	}
-	else if (!have_skill($skill[Juggle Fireballs]))
+	else if (!have_skill($skill[[25003]Juggle Fireballs]))
 	{
-		return zelda_buyableSkill($skill[Juggle Fireballs]);
+		return zelda_buyableSkill($skill[[25003]Juggle Fireballs]);
 	}
 	else if (!possessEquipment($item[cape]))
 	{
@@ -299,13 +299,13 @@ int zelda_ppCost(skill sk)
 {
 	switch(sk)
 	{
-		case $skill[Hammer Throw]:
-		case $skill[Juggle Fireballs]:
-		case $skill[Spin Jump]:
+		case $skill[[25001]Hammer Throw]:
+		case $skill[[25003]Juggle Fireballs]:
+		case $skill[[25005]Spin Jump]:
 			return 1;
-		case $skill[Ultra Smash]:
-		case $skill[Fireball Barrage]:
-		case $skill[Multi-Bounce]:
+		case $skill[[25002]Ultra Smash]:
+		case $skill[[25004]Fireball Barrage]:
+		case $skill[[25006]Multi-Bounce]:
 			return 2;
 		default:
 			return 0;
@@ -313,12 +313,12 @@ int zelda_ppCost(skill sk)
 }
 
 boolean [skill] zelda_combatSkills = $skills[
-	Hammer Throw,
-	Ultra Smash,
-	Juggle Fireballs,
-	Fireball Barrage,
-	Spin Jump,
-	Multi-Bounce,
+	[25001]Hammer Throw,
+	[25002]Ultra Smash,
+	[25003]Juggle Fireballs,
+	[25004]Fireball Barrage,
+	[25005]Spin Jump,
+	[25006]Multi-Bounce,
 ];
 
 // TODO: Remove this function when my_pp() works
@@ -345,17 +345,17 @@ boolean zelda_canDealScalingDamage()
 		return false;
 	}
 
-	if(auto_have_skill($skill[Multi-Bounce]))
+	if(auto_have_skill($skill[[25006]Multi-Bounce]))
 	{
 		return true;
 	}
 
-	if(auto_have_skill($skill[Fireball Barrage]) && zelda_haveFlower())
+	if(auto_have_skill($skill[[25004]Fireball Barrage]) && zelda_haveFlower())
 	{
 		return true;
 	}
 
-	if(auto_have_skill($skill[Ultra Smash]) && zelda_haveHammer())
+	if(auto_have_skill($skill[[25002]Ultra Smash]) && zelda_haveHammer())
 	{
 		return true;
 	}
@@ -370,15 +370,15 @@ boolean zelda_skillValid(skill sk)
 		return true;
 	}
 
-	if($skills[Jump Attack, Spin Jump, Multi-Bounce] contains sk)
+	if($skills[Jump Attack, [25005]Spin Jump, [25006]Multi-Bounce] contains sk)
 	{
 		return zelda_equippedBoots();
 	}
-	else if($skills[Fireball Toss, Juggle Fireballs, Fireball Barrage] contains sk)
+	else if($skills[Fireball Toss, [25003]Juggle Fireballs, [25004]Fireball Barrage] contains sk)
 	{
 		return zelda_equippedFlower();
 	}
-	else if($skills[Hammer Smash, Hammer Throw, Ultra Smash] contains sk)
+	else if($skills[Hammer Smash, [25001]Hammer Throw, [25002]Ultra Smash] contains sk)
 	{
 		return zelda_equippedHammer();
 	}


### PR DESCRIPTION
mafia now tracks skills more exactly and throws a fit when different skills exist with the same name and a script did not differentiate them via skill number.
Also its guesses on which skill it is are clearly wrong in some older paths.
