### PR TITLE
use chaos butterfly in barn if it was just acquired to save 1 adv

### DIFF
--- a/RELEASE/scripts/autoscend/auto_quest_level_12.ash
+++ b/RELEASE/scripts/autoscend/auto_quest_level_12.ash
@@ -1405,6 +1405,24 @@ boolean L12_farm()
 		}
 	}
 	
+	//if you just now acquired [chaos butterfly] and don't have anywhere to use it other than the barn or the war then use it in barn
+	//also contain code to account for being unable to use it for some reason
+	if(!get_property("chaosButterflyThrown").to_boolean() && item_amount($item[chaos butterfly]) > 0)
+	{
+		if($location[McMillicancuddy's Barn].turns_spent > 0)
+		{
+			auto_log_warning("I seem to have spent turns in [McMillicancuddy's Barn] without using the [chaos butterfly] which I have. Something is not right...", "red");
+		}
+		else if(adv_saved > adv_needed-15)
+		{
+			auto_log_warning("Looks like I should use the [chaos butterfly] in [McMillicancuddy's Barn]", "blue");
+			if(autoAdv(1, $location[McMillicancuddy's Barn]))
+			{
+				return true;
+			}
+		}		
+	}
+	
 	//final check and then we can start doing the farm
 	if(adv_saved > adv_needed)
 	{


### PR DESCRIPTION
# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
