### PR TITLE
leave 2 adventures at end of day

### DIFF
--- a/BUILD/settings/any.dat
+++ b/BUILD/settings/any.dat
@@ -35,6 +35,7 @@ auto_optimizeConsultsInRun	boolean	When true, optimize our consults in run to ge
 auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
 auto_consultChoice	string	The name of the player you want to do Zatara consults with.
 auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
+auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
 auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
 auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
 auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.

--- a/RELEASE/data/autoscend_settings.txt
+++ b/RELEASE/data/autoscend_settings.txt
@@ -43,16 +43,17 @@ any	33	auto_optimizeConsultsInRun	boolean	When true, optimize our consults in ru
 any	34	auto_consultClan	string	The clan name of the player you want to do Zatara consults with.
 any	35	auto_consultChoice	string	The name of the player you want to do Zatara consults with.
 any	36	auto_slowSteelOrgan	boolean	When true, don't immediately go for the Steel Organ (assuming we want a steel organ).
-any	37	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
-any	38	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
-any	39	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
-any	40	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
-any	41	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
-any	42	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
-any	43	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
-any	44	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
-any	45	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
-any	46	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
+any	37	auto_save_adv_override	integer	Set an override to amount of adv to save at end of day. Set to -1 to handle this automatically.
+any	38	auto_saveSausage	boolean	When true, in HCCS, do not eat the Sausage Without A Cause (may cause you to eat nothing on day 2).
+any	39	auto_saveVintage	boolean	When true, in HCCS, do not drink the Vintage Smart Drink (will cause +lbs quest to take 4 more adventures).
+any	40	auto_saveMagicalSausage	boolean	When true, don't eat magical sausage, so you can save them up for aftercore.
+any	41	auto_useWishes	boolean	When true, use the Genie Bottle to go faster in non-Community Service runs.
+any	42	auto_spoonsign	string	What sign to change to with the hewn moon-rune spoon after finishing any business in the current sign. If blank or invalid, we won't switch automatically. Can be set to any of the 9 main sign names, or knoll/canadia/gnomad to automatically select the appropriate sign within that zone based on your mainstat. Also some shorthands are allowed in case you forgot which moonsign is which, such as famweight/clover/food/booze. You will be prompted to confirm that you actually do want to change signs automatically once per ascension (although it will automatically assume that you do after 15 seconds of inactivity), so forgetting to change the value in advance should not be a concern.
+any	43	auto_MLSafetyLimit	integer	If set this will be the (approximate) cap for +ML. WARNING: Certain conditions may require the script to exceed this by a small margin. For best results set this 10 below the maximum ML you can handle.
+any	44	auto_disregardInstantKarma	boolean	When true, the script will not scale back ML after reaching Level 13, if you also set auto_MLSafetyLimit to 999 the script will passively power level. WARNING: You are unlikely to get Instant Karma (This is useful if your run preceeds The Sea, The Basement, or Dungeons)
+any	45	auto_secondPlaceOrBust	boolean	When true, abort before each tower test if we can't get to second place.
+any	46	auto_helpMeMafiaIsSuperBrokenAaah	boolean	Pretty much just for werebear. If for some reason you find that mafia completely fails to detect item drops occasionally, leading to wasting a ton of adventures continuing to look for an item you already found, try this out.
+any	47	auto_logLevel	string	One of: critical, error, warning, info, debug, trace. Sets the level of log output for autoscend gcli and session log output. Critical showing the least detail (only critical messages) and trace showing the most detail (print everything). Defaults to info.
 
 post	0	auto_getBeehive	boolean	Go for the beehive?
 post	1	auto_getStarKey	boolean	Get Richard's Star Key?

--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -224,6 +224,67 @@ void initializeSettings()
 	set_property("auto_doneInitialize", my_ascensions());
 }
 
+boolean auto_unreservedAdvRemaining()
+{
+	// Calculates if we should continue to run the main loop based on how many adv we want to keep.
+	
+	// blank int does not work properly. blank should default to -1
+	if(get_property("auto_save_adv_override") == "")
+	{
+		set_property("auto_save_adv_override", -1);
+	}
+	
+	// if auto_save_adv_override value is not -1 then use the override
+	if(get_property("auto_save_adv_override") != -1)
+	{
+		if(my_adventures() > get_property("auto_save_adv_override").to_int())
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	// automatically calculate adv to reserve at end of day
+	// free fights & free crafting require at least 1 adventure.
+	// cocktailcrafting and pasta cooking require 2 adventures.
+	
+	int reserveadv = 1;
+	
+	if((my_level() < 13 || get_property("auto_disregardInstantKarma").to_boolean()) && auto_freeCombatsRemaining() > 0)
+	{
+		reserveadv = max(2, reserveadv);
+	}
+	
+	if(freeCrafts() < 2)
+	{
+		//smallest Pasta dish that takes 2 adv to craft is 3 fullness.
+		//Pastamastery is required for all pasta and having it alone is enough to craft foods that take 2 adv to craft
+		if(can_eat() && my_fullness()+3 <= fullness_limit() && auto_have_skill($skill[Pastamastery]))
+		{
+			reserveadv = max(2, reserveadv);
+		}
+		
+		//Advanced Cocktailcrafting skill is enough to make drinks that cost 2 adv to craft
+		//because of nightcap, there is no point in checking your inebrity limits.
+		if(can_drink() && auto_have_skill($skill[Advanced Cocktailcrafting]))
+		{
+			reserveadv = max(2, reserveadv);
+		}
+	}
+	
+	if(my_adventures() > reserveadv)
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
 boolean handleFamiliar(string type)
 {
 	//Can this take zoneInfo into account?
@@ -2151,7 +2212,7 @@ boolean doBedtime()
 	boolean done = (my_inebriety() > inebriety_limit()) || (my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]);
 	if((my_class() == $class[Gelatinous Noob]) || !can_drink() || out_of_blood)
 	{
-		if((my_adventures() <= 1) || (internalQuestStatus("questL13Final") >= 14))
+		if((my_adventures() <= 2) || (internalQuestStatus("questL13Final") >= 14))
 		{
 			done = true;
 		}
@@ -2702,11 +2763,56 @@ boolean LX_getDigitalKey()
 	return true;
 }
 
+int auto_freeCombatsRemaining()
+{
+	int count = 0;
+	
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && !is100FamiliarRun())
+	{
+		count += 5-get_property("_machineTunnelsAdv").to_int();
+	}
+	if(snojoFightAvailable())
+	{
+		count += 10-get_property("_snojoFreeFights").to_int();
+	}
+	if(auto_have_familiar($familiar[God Lobster]) && !is100FamiliarRun())
+	{
+		count += 3-get_property("_godLobsterFights").to_int();
+	}
+	if(neverendingPartyAvailable())
+	{
+		count += 10-get_property("_neverendingPartyFreeTurns").to_int();
+	}
+	if(get_property("_eldritchTentacleFought").to_boolean() == false)
+	{
+		count++;
+	}
+	if(auto_have_skill($skill[Evoke Eldritch Horror]) && get_property("_eldritchHorrorEvoked").to_boolean() == false)
+	{
+		count++;
+	}
+	
+	return count;
+}
+
 boolean LX_freeCombats()
 {
 	if(my_inebriety() > inebriety_limit())
 	{
 		return false;
+	}
+	
+	if(my_adventures() == 0)
+	{
+		auto_log_warning("Could not use free combats because you are out of adventures", "red");
+		return false;
+	}
+	
+	if(my_adventures() < 2)
+	{
+		auto_log_warning("Too few adventures to safely automate free combats.", "red");
+		auto_log_warning("If we lose your last adv on a free combat the remaining free combats are wasted.", "red");
+		abort("Please perform the remaining free combats manually.");
 	}
 
 	if((auto_my_path() != "Disguises Delimit") && neverendingPartyCombat())
@@ -2714,7 +2820,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && (my_adventures() > 0) && !is100FamiliarRun())
+	if(!in_koe() && auto_have_familiar($familiar[Machine Elf]) && (get_property("_machineTunnelsAdv").to_int() < 5) && !is100FamiliarRun())
 	{
 		if(get_property("auto_choice1119") != "")
 		{
@@ -2743,7 +2849,7 @@ boolean LX_freeCombats()
 		return true;
 	}
 
-	if(snojoFightAvailable() && (my_adventures() > 0))
+	if(snojoFightAvailable())
 	{
 		handleFamiliar($familiar[Ms. Puck Man]);
 		autoAdv(1, $location[The X-32-F Combat Training Snowman]);
@@ -5137,7 +5243,9 @@ void auto_begin()
 		use_familiar($familiar[none]);
 	}
 	dailyEvents();
-	while((my_adventures() > 1) && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !get_property("kingLiberated").to_boolean() && doTasks())
+	
+	// the main loop of autoscend is doTasks() which is actually called as part of the while.
+	while(auto_unreservedAdvRemaining() && (my_inebriety() <= inebriety_limit()) && !(my_inebriety() == inebriety_limit() && my_familiar() == $familiar[Stooper]) && !get_property("kingLiberated").to_boolean() && doTasks())
 	{
 		if((my_fullness() >= fullness_limit()) && (my_inebriety() >= inebriety_limit()) && (my_spleen_use() == spleen_limit()) && (my_adventures() < 4) && (my_rain() >= 50) && (get_counters("Fortune Cookie", 0, 4) == "Fortune Cookie"))
 		{

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -267,6 +267,8 @@ boolean useCocoon();
 
 
 //Large pile dump.
+int auto_freeCombatsRemaining();							//Defined in autoscend.ash
+boolean auto_unreservedAdvRemaining();						//Defined in autoscend.ash
 boolean L12_sonofaPrefix();									//Defined in autoscend.ash
 boolean L9_ed_chasmBuildClover(int need);					//Defined in autoscend/auto_edTheUndying.ash
 boolean L9_ed_chasmStart();									//Defined in autoscend/auto_edTheUndying.ash


### PR DESCRIPTION
1 adventure is not enough. you sometimes need 2 adventures in order to craft the food/drink you want to consume. also 1 adv leaves too little room for error with free fights as those will consume an adventure if you lose.

# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
