### PR TITLE
Ed NC death handling.

### DIFF
--- a/RELEASE/scripts/autoscend.ash
+++ b/RELEASE/scripts/autoscend.ash
@@ -3126,6 +3126,7 @@ void resetState() {
 	set_property("auto_familiarChoice", ""); // which familiar do we want to switch to during pre_adventure
 	set_property("choiceAdventure1387", -1); // using the force non-combat
 	set_property("_auto_tunedElement", ""); // Flavour of Magic elemental alignment
+	set_property("_auto_edNoLinenCheck", false); // ed went into a zone with NCs that deal damage without linen bandages
 
 	set_property("auto_januaryToteAcquireCalledThisTurn", false); // january tote item switching
 

--- a/RELEASE/scripts/autoscend/auto_post_adv.ash
+++ b/RELEASE/scripts/autoscend/auto_post_adv.ash
@@ -1033,6 +1033,18 @@ boolean auto_post_adventure()
 			abort("We have been disavowed...");
 		}
 	}
+	
+	if(isActuallyEd() && my_hp() == 0)
+	{
+		acquireHP(1);
+		if(my_hp() == 0 && get_property("_auto_edNoLinenCheck").to_boolean())	//we got beaten up in a risky NC as ed
+		{
+			if(!edUnderworldAdv())	//try to spend 1 adv to restore HP
+			{
+				abort("Failed to rest as ed");
+			}
+		}
+	}
 
 	set_property("auto_combatDirective", "");
 	set_property("auto_digitizeDirective", "");

--- a/RELEASE/scripts/autoscend/autoscend_header.ash
+++ b/RELEASE/scripts/autoscend/autoscend_header.ash
@@ -408,6 +408,8 @@ boolean L1_ed_island();
 boolean L1_ed_islandFallback();
 boolean L9_ed_chasmStart();
 boolean L9_ed_chasmBuildClover(int need);
+boolean edHarmfulNoncombatCheck(boolean softblock);
+boolean edUnderworldAdv();
 boolean LM_edTheUndying();
 void edUnderworldChoiceHandler(int choice);
 

--- a/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
+++ b/RELEASE/scripts/autoscend/paths/actually_ed_the_undying.ash
@@ -1231,6 +1231,52 @@ boolean L9_ed_chasmBuildClover(int need)
 	return false;
 }
 
+boolean edHarmfulNoncombatCheck(boolean softblock)
+{
+	//checks if ed is prepared to go into a zone where NC damage might kill him.
+	//returns true if ed is NOT prepared. use in dangerous locations with (assuming softblock): if(edHarmfulNoncombatCheck(true)) return false;
+	//softblock == true is used for main quests which should be done anyways if we are about to powerlevel.
+	//softblock == false is used for optional quests which should be hard blocked if we cannot handle NC damage.
+	
+	if(!isActuallyEd())
+	{
+		return false;
+	}
+	
+	boolean hasNoLinen = item_amount($item[Linen Bandages]) == 0;
+	
+	if(softblock && isAboutToPowerlevel() && hasNoLinen)
+	{
+		auto_log_info("We are about to powerlevel so instead we are taking a risk and going into a dangerous NC zone without Linen Bandages", "blue");
+		set_property("_auto_edNoLinenCheck", true);
+		return false;
+	}
+	
+	return hasNoLinen;
+}
+
+boolean edUnderworldAdv()
+{
+	//This function is used to spend 1 adv "resting" as ed by entering the underworld via the gate at his pyramid, shopping, then leaving.
+	//Should only be called it really necessary. Such as if we died to an NC damage and have no restorers.
+	
+	if(!isActuallyEd())
+	{
+		abort("edUnderworldAdv() should not have been called as not ed.");
+	}
+	
+	int initial_turncount = my_turncount();
+
+	visit_url("place.php?whichplace=edbase&action=edbase_portal");		//click on portal in base
+	run_choice(1);		// Enter the Underworld
+	run_choice(1);		// Need to click through another window
+	ed_shopping();		// Shop while there
+	visit_url("place.php?whichplace=edunder&action=edunder_leave");		//click on portal in underworld
+	run_choice(1);		// Exit the Underworld
+	
+	return my_turncount() == 1 + initial_turncount;
+}
+
 boolean LM_edTheUndying()
 {
 	if (!isActuallyEd())

--- a/RELEASE/scripts/autoscend/quests/level_12.ash
+++ b/RELEASE/scripts/autoscend/quests/level_12.ash
@@ -1073,6 +1073,10 @@ boolean L12_sonofaBeach()
 	{
 		return false;
 	}
+	if(edHarmfulNoncombatCheck(true))	//is ed ready to take this risk?
+	{
+		return false;	//ed is not prepared. delay
+	}
 
 	//Seriously? http://alliancefromhell.com/viewtopic.php?t=1338
 	if(item_amount($item[Wool Hat]) == 1)

--- a/RELEASE/scripts/autoscend/quests/level_any.ash
+++ b/RELEASE/scripts/autoscend/quests/level_any.ash
@@ -503,6 +503,17 @@ boolean LX_dailyDungeonToken()
 		}
 	}
 	
+	boolean has_pole = item_amount($item[Eleven-Foot Pole]) > 0;
+	boolean has_picks = item_amount($item[Platinum Yendorian Express Card]) > 0 || item_amount($item[Pick-O-Matic Lockpicks]) > 0;
+	
+	//Ed will be doing daily dungeon if auto_forceFatLootToken == true
+	if(!has_pole &&		//can take NC damage from traps
+	!has_picks &&		//can take NC damage from doors
+	edHarmfulNoncombatCheck(false))	//is ed and unable to handle dying from NC damage without wasting adventures
+	{
+		return false;
+	}
+	
 	// make sure we have enough adventures. since partial completion means wasted adventures.
 	int adv_budget = my_adventures() - auto_advToReserve();
 	if(adv_budget < 1 + ceil(estimateDailyDungeonAdvNeeded()))


### PR DESCRIPTION
Try to avoid dying to NCs by only risking a dangerous NC if you have linen bandages or if you are about to powerlevel (ran out of things to do). If we do die to an NC and cannot restore HP above zero then spend an adventure on going to the underworld to recover instead.
*boolean edHarmfulNoncombatCheck(boolean softblock) created.
**checks if ed is prepared to go into a zone where NC damage might kill him.
**returns true if ed is NOT prepared. use in dangerous locations with: if(edHarmfulNoncombatCheck()) return false;
**softblock == true is used for main quests which should be done anyways if we are about to powerlevel.
**softblock == false is used for optional quests which should be hard blocked if we cannot handle NC damage.
*boolean edUnderworldAdv() created.
**This function is used to spend 1 adv "resting" as ed by entering the underworld via the gate at his pyramid, shopping, then leaving.
**Should only be called it really necessary. Such as if we died to an NC damage and have no restorers.
*used in sonofa beach
*used in daily dungeon

# Description

Please include a summary of the change. Pull requests should generally be against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) which will eventually be merged into master once beta changes are sufficiently vetted.

If it addresses a particular issue, please put the issue numbers below (see also [Closing Issues Using Keywords](https://help.github.com/en/articles/closing-issues-using-keywords)).

Fixes # (issue)

## How Has This Been Tested?

Testing ASH scripts is tricky and generally involves you doing multiple runs with a change to see how it performs. If you did any particular tests, or have particular tests you would like to do but cant (e.g. need to test with an expensive item you dont have access to) please mention that here. Relevant Mafia session logs may also be helpful.

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have based by pull request against the [beta branch](https://github.com/Loathing-Associates-Scripting-Society/autoscend/tree/beta) or have a good reason not to.
